### PR TITLE
Master

### DIFF
--- a/Macher_Daach_Badge_Doku.tex
+++ b/Macher_Daach_Badge_Doku.tex
@@ -53,25 +53,13 @@ Folgende Bauteile sollten in der Tüte drin sein:
 	\item Knopfzelle
 \end{enumerate}
 
-\newpage
-
 \begin{center}
-\includegraphics[width=\textwidth]{Bilder2023/IMG_8334.JPG}
+\includegraphics[width=15cm]{Bilder2023/IMG_8334.JPG}
 \captionof{figure}{Alle Bauteile auf einen Blick}
 \label{fig:all_components}
 \end{center}
 
-\section{Dokumentation ist alles}
-
-Die Hardware, Software und selbstverständlich diese Anleitung sind Open Source. Wenn du sie dir ansehen, sie herunterladen oder daran mitarbeiten möchtest, musst du nur folgenden Links folgen:
-
-\begin{itemize}
-	\item \url{https://github.com/casartar/MacherDaachBadgeFirmware}
-	\item \url{https://github.com/casartar/MacherDaachBadgeHardware}
-	\item \url{https://github.com/casartar/MacherDaachBadgeDoku}
-\end{itemize}
-
-Oder suche auf github.com nach Macherdaach.
+\newpage
 
 \section{Jetzt geht es richtig los}
 Wir löten die Bauteile nach der Regel: Das niedrigste Bauteil zuerst.
@@ -121,7 +109,7 @@ Zum Schluss müssen die überstehenden Beinchen noch mit der Zange abgezwickt we
 	%\label{fig:}
 \end{minipage}
 
-\vspace{0.5cm}
+\newpage
 
 \subsection{Sockel für den Mikrocontroller}
 
@@ -165,6 +153,8 @@ Wenn der Sockel richtig sitzt, kannst du die Platine wieder umdrehen und die Pla
 	%\label{fig:}
 \end{minipage}
 
+\newpage
+
 \subsection{Knopfzellenhalter - BT1}
 
 Bevor du den Knopfzellenhalter anlöten darfst, musst du die große runde silberne Fläche mit Lötzinn versehen. Dazu lässt du ein kleines bisschen Lötzinn auf der Fläche schmelzen und verteilst sie mit dem Lötkolben, indem du den Lötkolben kreisförmig über die Fläche bewegst.
@@ -189,36 +179,30 @@ Wenn du den Knopfzellenhalter festlötest, wirst du merken, dass das nicht so ei
 \vspace{0.5cm}
 
 \begin{minipage}[b]{0.5\textwidth}
-	\includegraphics[width=\textwidth]{Bilder2023/IMG_8361.JPG}
-	%\captionof{figure}{}
-	%\label{fig:}
-\end{minipage}
-\begin{minipage}[b]{0.5\textwidth}
 	\includegraphics[width=\textwidth]{Bilder2023/IMG_8362.JPG}
 	%\captionof{figure}{}
 	%\label{fig:}
 \end{minipage}
-
-\vspace{0.5cm}
-
 \begin{minipage}[b]{0.5\textwidth}
 	\includegraphics[width=\textwidth]{Bilder2023/IMG_8363.JPG}
 	%\captionof{figure}{}
 	%\label{fig:}
 \end{minipage}
+
+\vspace{0.5cm}
+
 \begin{minipage}[b]{0.5\textwidth}
 	\includegraphics[width=\textwidth]{Bilder2023/IMG_8364.JPG}
 	%\captionof{figure}{}
 	%\label{fig:}
 \end{minipage}
-
-\vspace{0.5cm}
-
 \begin{minipage}[b]{0.5\textwidth}
 	\includegraphics[width=\textwidth]{Bilder2023/IMG_8365.JPG}
 	%\captionof{figure}{}
 	%\label{fig:}
 \end{minipage}
+
+\newpage
 
 \subsection{An/Aus-Schalter - SW3}
 
@@ -265,6 +249,8 @@ Nun kannst du mit dem Zeigefinger den Schalter von hinten auf die Platine drück
 	%\label{fig:}
 \end{minipage}
 
+\newpage
+
 \subsection{LED-Matrix - D1}
 
 \textbf{Im Gegensatz zum Mikrocontrollersockel verzeiht dir die LED-Matrix nicht, wenn du sie falsch herum auflötest.} 
@@ -299,6 +285,8 @@ Beim Löten machst du das am Besten so wie beim Mikrocontrollersockel. Du lötes
 	%\label{fig:}
 \end{minipage}
 
+\newpage
+
 \subsection{Taster - SW1 und SW2}
 
 Um die Taster in die Bohrlöcher zu bekommen, musst du ein bisschen fummeln. Wenn sie mal sitzen, fallen sie von alleine nicht mehr heraus und das Festlöten geht ganz einfach von der Hand.
@@ -325,6 +313,8 @@ Die Taster kann man zum Glück auch nicht falsch herum anlöten.
 	%\captionof{figure}{}
 	%\label{fig:}
 \end{minipage}
+
+\newpage
 
 \subsection{Elektrolytkondensator - C1 (100 $\mu$F)}
 
@@ -360,6 +350,8 @@ Die Beinchen des Elkos sind ein bisschen zu weit auseinander für die Bohrungen 
 	%\label{fig:}
 \end{minipage}
 
+\newpage
+
 \section{Einsetzen der Knopfzelle}
 
 Jetzt musst du nur noch die Knopfzelle in den Knopfzellenhalter schieben.
@@ -391,7 +383,7 @@ Achtung! Das Plus-Zeichen muss nach oben schauen.
 	%\label{fig:}
 \end{minipage}
 
-\vspace{0.5cm}
+\newpage
 
 \section{An der Programmierstation}
 
@@ -427,8 +419,7 @@ Ist der Controller programmiert, musst du ihn nur noch in den Sockel einsetzen.
 	%\label{fig:}
 \end{minipage}
 
-\vspace{0.5cm}
-
+\newpage
 
 \section{Was tut es?}
 
@@ -450,6 +441,18 @@ Ein zwei Personen-Spiel auf kleinstem Raum. Drücke Deine Taste, wenn der Ball k
 %Die Schlange macht lustige Runden über das Display, am einen Rand raus, am anderen wieder rein. Sie stößt mit sich selbst nicht zusammen und ist darum unsterblich. Je länger sie %wird, um so schneller flitzt sie rum und wenn sie alt wird, verzehrt sie sich langsam wieder selbst. Endloser Spaß für die ganze Familie!\\
 
 %Mit den beiden Tastern kann man die Schlange nach links und rechts abbiegen lassen und so versuchen die Mäuse zu fangen.
+
+\section{Dokumentation ist alles}
+
+Die Hardware, Software und selbstverständlich diese Anleitung sind Open Source. Wenn du sie dir ansehen, sie herunterladen oder daran mitarbeiten möchtest, musst du nur folgenden Links folgen:
+
+\begin{itemize}
+	\item \url{https://github.com/casartar/MacherDaachBadgeFirmware}
+	\item \url{https://github.com/casartar/MacherDaachBadgeHardware}
+	\item \url{https://github.com/casartar/MacherDaachBadgeDoku}
+\end{itemize}
+
+Oder suche auf github.com nach Macherdaach.
 
 \bibliographystyle{plain}
 \bibliography{references}


### PR DESCRIPTION
During macherdaach 2023 I noticed, that people were confused, because text and corresponding pictures were not on the same page in the printed documentation.

This PR restructures the document to fix this issue for the future.

Changes:
1. shrink the first picture, with the part-overview, that it fits on the same page as the part-list

2. include page-breaks that all major steps start on a new page

3. move links to documentation at the end of the document

4. remove one picture from the battery-holder page to be able to fit this part on one page

